### PR TITLE
予定ページを初めて開いた時点で、自分の出欠をDBに追加するように修正

### DIFF
--- a/routes/schedules.js
+++ b/routes/schedules.js
@@ -85,6 +85,14 @@ router.get('/:scheduleId', authenticationEnsurer, async (req, res, next) => {
       candidates.forEach((c) => {
         const map = availabilityMapMap.get(u.userId) || new Map();
         const a = map.get(c.candidateId) || 0; // デフォルト値は 0 を利用
+        if (!map.get(c.candidateId)) { // 出欠の値がない場合、ここでデータベースに追加
+          Availability.upsert({
+            scheduleId: schedule.scheduleId,
+            userId: u.userId,
+            candidateId: c.candidateId,
+            availability: a
+          });
+        }
         map.set(c.candidateId, a);
         availabilityMapMap.set(u.userId, map);
       });


### PR DESCRIPTION
現在、出欠ボタンを最低一回押さないとDBに保存されない（予定ページを初めて開いて何も押さず閉じると、ユーザーは候補をすべて「欠」にしたと感じるが、実際にはDBには何も保存されていない。よって当然、他の人からも確認できない）の問題を修正した